### PR TITLE
browser-secure example: check for access, and link to login page

### DIFF
--- a/examples/browser-secure/index.html
+++ b/examples/browser-secure/index.html
@@ -18,7 +18,7 @@
     </p>
     <div>
       Kernel:
-      <pre id="kernel-info">Starting...</pre>
+      <pre id="kernel-info">Authorizing...</pre>
     </div>
     <textarea id="cell" cols="100" rows="24"></textarea>
     <div>
@@ -33,6 +33,6 @@
         }
     });
     </script>
-    <script src="/static/index.js"></script>
+    <script src={{static_url("index.js")}}></script>
   </body>
 </html>


### PR DESCRIPTION
Checks for access to listing kernels, and adds a link to the login page if access is denied.

Tested to work with Chrome, Safari.

Things that I don't like too much, but couldn't quite figure out:
- error doesn't appear to include HTTP status, and I only want to do this on 403
- login page can't redirect back to our demo page (fixed by https://github.com/jupyter/notebook/pull/1642),
  so I made a link instead of a login redirect.
